### PR TITLE
feat: add Norwegian as supported language

### DIFF
--- a/py_modules/providers/chromescreenai_provider.py
+++ b/py_modules/providers/chromescreenai_provider.py
@@ -34,7 +34,7 @@ class ChromeScreenAIProvider(OCRProvider):
     # Engine auto-detects across 77+ scripts; we just advertise what the
     # rest of the plugin supports plus 'auto'.
     SUPPORTED_LANGUAGES = [
-        'auto', 'ar', 'bg', 'zh-CN', 'zh-TW', 'hr', 'cs', 'da', 'nl', 'en',
+        'auto', 'ar', 'bg', 'zh-CN', 'zh-TW', 'hr', 'cs', 'da', 'nl', 'no', 'en',
         'fi', 'fr', 'de', 'el', 'hi', 'hu', 'it', 'ja', 'ko', 'pl', 'pt',
         'ro', 'ru', 'es', 'sv', 'th', 'tr', 'uk', 'vi',
     ]

--- a/py_modules/providers/free_translate.py
+++ b/py_modules/providers/free_translate.py
@@ -35,6 +35,7 @@ class FreeTranslateProvider(TranslationProvider):
         'el': 'el',
         'fi': 'fi',
         'nl': 'nl',
+        'no': 'no',
         'pl': 'pl',
         'tr': 'tr',
         'uk': 'uk',

--- a/py_modules/providers/google_ocr.py
+++ b/py_modules/providers/google_ocr.py
@@ -19,7 +19,7 @@ class GoogleVisionProvider(OCRProvider):
 
     SUPPORTED_LANGUAGES = [
         'auto', 'en', 'ja', 'zh-CN', 'zh-TW', 'ko', 'de', 'fr', 'es', 'it',
-        'pt', 'ru', 'ar', 'nl', 'pl', 'tr', 'uk', 'hi', 'el', 'th', 'vi', 'fi', 'id', 'ro', 'bg', 'hr',
+        'pt', 'ru', 'ar', 'nl', 'no', 'pl', 'tr', 'uk', 'hi', 'el', 'th', 'vi', 'fi', 'id', 'ro', 'bg', 'hr',
         'cs', 'hu', 'sv', 'da'
     ]
 

--- a/py_modules/providers/google_translate.py
+++ b/py_modules/providers/google_translate.py
@@ -17,7 +17,7 @@ class GoogleTranslateProvider(TranslationProvider):
 
     SUPPORTED_LANGUAGES = [
         'auto', 'en', 'ja', 'zh-CN', 'zh-TW', 'ko', 'de', 'fr', 'es', 'it',
-        'pt', 'ru', 'ar', 'nl', 'pl', 'tr', 'uk', 'hi', 'el', 'th', 'vi', 'fi', 'id', 'ro', 'bg', 'hr',
+        'pt', 'ru', 'ar', 'nl', 'no', 'pl', 'tr', 'uk', 'hi', 'el', 'th', 'vi', 'fi', 'id', 'ro', 'bg', 'hr',
         'cs', 'hu', 'sv', 'da'
     ]
 

--- a/py_modules/providers/nllb_downloader.py
+++ b/py_modules/providers/nllb_downloader.py
@@ -24,6 +24,7 @@ NLLB_LANG_MAP = {
     "ru": "rus_Cyrl",
     "ar": "arb_Arab",
     "nl": "nld_Latn",
+    "no": "nob_Latn",  # Norwegian Bokmål
     "pl": "pol_Latn",
     "tr": "tur_Latn",
     "uk": "ukr_Cyrl",

--- a/py_modules/providers/ocrspace.py
+++ b/py_modules/providers/ocrspace.py
@@ -49,6 +49,7 @@ class OCRSpaceProvider(OCRProvider):
         'el': 'gre',
         'fi': 'fin',
         'nl': 'dut',
+        'no': 'nor',
         'pl': 'pol',
         'tr': 'tur',
         'uk': 'ukr',

--- a/py_modules/providers/rapidocr_provider.py
+++ b/py_modules/providers/rapidocr_provider.py
@@ -67,6 +67,7 @@ class RapidOCRProvider(OCRProvider):
         'it': 'latin',
         'pt': 'latin',
         'nl': 'latin',
+        'no': 'latin',
         'pl': 'latin',
         'tr': 'latin',
         'ro': 'latin',
@@ -86,8 +87,8 @@ class RapidOCRProvider(OCRProvider):
 
     SUPPORTED_LANGUAGES = [
         'auto', 'en', 'zh-CN', 'zh-TW', 'ja', 'ko',
-        'de', 'fr', 'es', 'it', 'pt', 'nl', 'pl', 'tr', 'ro', 'vi', 'fi', 'hr',
-        'cs', 'hu', 'sv', 'da',
+        'de', 'fr', 'es', 'it', 'pt', 'nl', 'no', 'pl', 'tr', 'ro', 'vi', 'fi',
+        'hr', 'cs', 'hu', 'sv', 'da',
         'ru', 'uk', 'bg', 'el', 'th'
     ]
 

--- a/src/tabs/TabTranslation.tsx
+++ b/src/tabs/TabTranslation.tsx
@@ -55,6 +55,7 @@ const languageOptions = [
     { label: "\ud83c\uddee\ud83c\uddf9 Italian", data: "it" },
     { label: "\ud83c\uddef\ud83c\uddf5 Japanese", data: "ja" },
     { label: "\ud83c\uddf0\ud83c\uddf7 Korean", data: "ko" },
+    { label: "\ud83c\uddf3\ud83c\uddf4 Norwegian", data: "no" },
     { label: "\ud83c\uddf5\ud83c\uddf1 Polish", data: "pl" },
     { label: "\ud83c\uddf5\ud83c\uddf9 Portuguese", data: "pt" },
     { label: "\ud83c\uddf7\ud83c\uddf4 Romanian", data: "ro" },
@@ -73,7 +74,7 @@ const outputLanguageOptions = languageOptions.filter(lang => lang.data !== "auto
 // Languages RapidOCR able to work with
 const rapidocrLanguages = new Set([
     'en', 'zh-CN', 'zh-TW', 'ja', 'ko',
-    'de', 'fr', 'es', 'it', 'pt', 'nl', 'pl', 'tr', 'ro', 'vi', 'fi', 'hr',
+    'de', 'fr', 'es', 'it', 'pt', 'nl', 'no', 'pl', 'tr', 'ro', 'vi', 'fi', 'hr',
     'cs', 'hu', 'sv', 'da',
     'ru', 'uk', 'el', 'th', 'bg'
 ]);


### PR DESCRIPTION
It seems all providers already support Norwegian, even though it was not exposed via the UI. Add it to the UI and into the relevant lists of supported languages.